### PR TITLE
Add point generation and display in Line class

### DIFF
--- a/004/line.js
+++ b/004/line.js
@@ -70,7 +70,27 @@ export class Line {
       this.drawDot(ctx, point.x, point.y);
     }
 
-    let start = this.points[0];
+    let begin = this.points[0];
+    const last = this.points[this.points.length - 1];
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.moveTo(begin.x, begin.y);
+
+    for (let i = 1; i < this.points.length; i++) {
+      const current = this.points[i];
+      ctx.lineTo(current.x, begin.y);
+      ctx.lineTo(current.x, current.y);
+      ctx.lineTo(begin.x, current.y);
+      ctx.lineTo(begin.x, begin.y);
+      ctx.moveTo(current.x, current.y);
+      begin = current;
+    }
+
+    ctx.fillStyle = "rgba(105, 105, 230, 0.5)";
+    ctx.fill();
+    ctx.closePath();
+    ctx.restore();
 
     if (this.drag) {
       this.openDragRange(ctx);

--- a/004/line.js
+++ b/004/line.js
@@ -9,7 +9,54 @@ export class Line {
     this.drag = false;
     this.gap = 10;
     this.dragCornerRectSize = 10;
+
+    this.points = [];
+    this.intervals = 20;
   }
+
+  updatePoints = () => {
+    for (let i = 0; i <= this.intervals; i++) {
+      const ratio = i / this.intervals;
+      const x = this.x1 + (this.x2 - this.x1) * ratio;
+      const y = this.y1 + (this.y2 - this.y1) * ratio;
+      this.points.push({ x, y });
+    }
+  };
+
+  openDragRange = (ctx) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.roundRect(
+      this.x1 + this.dragCornerRectSize / 2,
+      this.y1 + this.dragCornerRectSize / 2,
+      -this.dragCornerRectSize,
+      -this.dragCornerRectSize,
+      4
+    );
+    ctx.roundRect(
+      this.x2 + this.dragCornerRectSize / 2,
+      this.y2 + this.dragCornerRectSize / 2,
+      -this.dragCornerRectSize,
+      -this.dragCornerRectSize,
+      4
+    );
+    ctx.fillStyle = "#ffffff";
+    ctx.fill();
+    ctx.strokeStyle = "rgba(105, 105, 230, 0.5)";
+    ctx.stroke();
+    ctx.closePath();
+    ctx.restore();
+  };
+
+  drawDot = (ctx, x, y) => {
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(x, y, 2, 0, Math.PI * 2);
+    ctx.fillStyle = "black";
+    ctx.fill();
+    ctx.closePath();
+    ctx.restore();
+  };
 
   draw = (ctx) => {
     ctx.beginPath();
@@ -17,30 +64,16 @@ export class Line {
     ctx.lineTo(this.x2, this.y2);
     ctx.strokeStyle = "black";
     ctx.stroke();
+    ctx.closePath();
+
+    for (const point of this.points) {
+      this.drawDot(ctx, point.x, point.y);
+    }
+
+    let start = this.points[0];
 
     if (this.drag) {
-      ctx.save();
-      ctx.beginPath();
-      ctx.roundRect(
-        this.x1 + this.dragCornerRectSize / 2,
-        this.y1 + this.dragCornerRectSize / 2,
-        -this.dragCornerRectSize,
-        -this.dragCornerRectSize,
-        4
-      );
-      ctx.roundRect(
-        this.x2 + this.dragCornerRectSize / 2,
-        this.y2 + this.dragCornerRectSize / 2,
-        -this.dragCornerRectSize,
-        -this.dragCornerRectSize,
-        4
-      );
-      ctx.fillStyle = "#ffffff";
-      ctx.fill();
-      ctx.strokeStyle = "rgba(105, 105, 230, 0.5)";
-      ctx.stroke();
-      ctx.closePath();
-      ctx.restore();
+      this.openDragRange(ctx);
     }
   };
 }

--- a/004/lineStorage.js
+++ b/004/lineStorage.js
@@ -7,11 +7,6 @@ export class LineStorage {
     this.tempPoint2 = null;
     this.point1 = null;
     this.point2 = null;
-
-    /**
-     * 두 점의 좌표들의 모음
-     */
-    this.storage = new Set();
   }
 
   resize = (stageWidth, stageHeight) => {
@@ -35,7 +30,8 @@ export class LineStorage {
       }
 
       const line = new Line(this.point1.x, this.point1.y, this.tempPoint2.x, this.tempPoint2.y);
-      this.storage.add(line);
+      line.updatePoints();
+
       this.point1 = null;
       this.point2 = null;
       this.tempPoint1 = null;


### PR DESCRIPTION
This pull request introduces significant updates to the `Line` and `LineStorage` classes in the `004` directory to enhance functionality for drawing and managing lines. The changes include adding support for intermediate points along lines, visualizing these points with dots, and updating the rendering logic to include a shaded rectangular area between points.

### Enhancements to the `Line` class:
* Added a `points` array and an `intervals` property to store intermediate points along a line. Introduced the `updatePoints` method to calculate these points based on the line's start and end coordinates.
* Implemented a `drawDot` method to render small dots at each intermediate point along the line.
* Updated the `draw` method to:
  - Render the line as before.
  - Draw dots at each intermediate point using `drawDot`.
  - Add a shaded rectangular area between consecutive points for enhanced visual representation.

### Modifications to the `LineStorage` class:
* Removed the unused `storage` property, simplifying the class.
* Updated the logic for creating a new line:
  - Added a call to the `updatePoints` method on the `Line` instance to ensure intermediate points are calculated immediately after the line is created.